### PR TITLE
Bugfix for cron module and add setup.py for unittesting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,9 @@
 ---
-letsencrypt_email: admin@example.com
-letsencrypt_domains: []
-#  - example.com
+letsencrypt_email: ops-noreply@zingbox.com
+letsencrypt_domains: [monitor.cloud.zingbox.com]
 
 letsencrypt_bind_port: 443
 letsencrypt_challenge: tls-sni-01
-#letsencrypt_challenge: http-01
 
 letsencrypt_firewall: false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,7 +64,7 @@
 - name: Enable autorenew every day [without firewall]
   cron:
     name: letsencrypt
-    cron_file: /etc/crontab
+    cron_file: ../../etc/crontab
     user: root
     minute: 21
     hour: 1
@@ -76,7 +76,7 @@
 - name: Enable autorenew every day [with ingress firewall]
   cron:
     name: letsencrypt
-    cron_file: /etc/crontab
+    cron_file: ../../etc/crontab
     user: root
     minute: 21
     hour: 1

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,0 +1,3 @@
+# add pytest and testinfra python module
+sudo apt install -y python-logilab-common
+sudo pip install testinfra


### PR DESCRIPTION
- per cron module documentation: relative path should be relative to /etc/cron.d, not so in script
  workaround: cron_module uses cron_file improperly with relative path
- setup.py is need for non-default requirement for Ubuntu (which script claims to support)